### PR TITLE
Change mv action of client binaries to rsync -a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:18.04
-LABEL version="Velociraptor v0.5.1"
+LABEL version="Velociraptor v0.6.1"
 LABEL description="Velociraptor server in a Docker container"
 LABEL maintainer="Wes Lambert, @therealwlambert"
-ENV VERSION="0.5.1"
+ENV VERSION="0.6.1"
 COPY ./entrypoint .
 RUN chmod +x entrypoint && \
     apt-get update && \
-    apt-get install -y curl wget jq && \
+    apt-get install -y curl wget jq rsync && \
     # Create dirs for Velo binaries
     mkdir -p /opt/velociraptor && \
     for i in linux mac windows; do mkdir -p /opt/velociraptor/$i; done && \

--- a/entrypoint
+++ b/entrypoint
@@ -10,9 +10,9 @@ CLIENT_DIR="/velociraptor/clients"
 
 # Move binaries into place
 cp /opt/velociraptor/linux/velociraptor . && chmod +x velociraptor
-mkdir -p $CLIENT_DIR/linux && cp /opt/velociraptor/linux/velociraptor /velociraptor/clients/linux/velociraptor_client
-mkdir -p $CLIENT_DIR/mac && mv /opt/velociraptor/mac/velociraptor_client /velociraptor/clients/mac/velociraptor_client
-mkdir -p $CLIENT_DIR/windows && mv /opt/velociraptor/windows/velociraptor_client* /velociraptor/clients/windows/
+mkdir -p $CLIENT_DIR/linux && rsync -a /opt/velociraptor/linux/velociraptor /velociraptor/clients/linux/velociraptor_client
+mkdir -p $CLIENT_DIR/mac && rsync -a /opt/velociraptor/mac/velociraptor_client /velociraptor/clients/mac/velociraptor_client
+mkdir -p $CLIENT_DIR/windows && rsync -a /opt/velociraptor/windows/velociraptor_client* /velociraptor/clients/windows/
 
 # If no existing server config, set it up
 if [ ! -f server.config.yaml ]; then


### PR DESCRIPTION
This change is to leave client binaries in place, as they seem to be required to build offline collectors. Additionally, an error can occur when the entrypoint script tries to move the binary a second time and it no longer exists.

I used rsync for this as it has logic to only perform the copy when the destination file is different, and this could save time on startup. Initially, I tried to put symlinks in to save on storage space but unfortunately it didn't work well with the bind mounted volume.

Feel free to implement an alternative way, but I think this method is okay.

I believe this resolves issue #3 