### PR TITLE
upgrade base image + velociraptor release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:20.04
 LABEL version="Velociraptor v0.6.4"
 LABEL description="Velociraptor server in a Docker container"
 LABEL maintainer="Wes Lambert, @therealwlambert"
-ENV VERSION="0.6.4 "
 COPY ./entrypoint .
 RUN chmod +x entrypoint && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04
-LABEL version="Velociraptor v0.6.1"
+FROM ubuntu:20.04
+LABEL version="Velociraptor v0.6.4"
 LABEL description="Velociraptor server in a Docker container"
 LABEL maintainer="Wes Lambert, @therealwlambert"
-ENV VERSION="0.6.1"
+ENV VERSION="0.6.4 "
 COPY ./entrypoint .
 RUN chmod +x entrypoint && \
     apt-get update && \

--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,6 @@
 set -e
 BIND_ADDRESS="0.0.0.0"
 PUBLIC_PATH="public"
-LOG_DIR="."
 CLIENT_DIR="/velociraptor/clients"
 
 # Move binaries into place

--- a/entrypoint
+++ b/entrypoint
@@ -3,7 +3,6 @@ set -e
 BIND_ADDRESS="0.0.0.0"
 PUBLIC_PATH="public"
 LOG_DIR="."
-SERVER_URL="https://VelociraptorServer:8000/"
 DATASTORE_LOCATION="./"
 FILESTORE_DIRECTORY="./"
 CLIENT_DIR="/velociraptor/clients"

--- a/entrypoint
+++ b/entrypoint
@@ -2,6 +2,10 @@
 set -e
 BIND_ADDRESS="0.0.0.0"
 PUBLIC_PATH="public"
+LOG_DIR="."
+SERVER_URL="https://VelociraptorServer:8000/"
+DATASTORE_LOCATION="./"
+FILESTORE_DIRECTORY="./"
 CLIENT_DIR="/velociraptor/clients"
 
 # Move binaries into place

--- a/entrypoint
+++ b/entrypoint
@@ -3,9 +3,6 @@ set -e
 BIND_ADDRESS="0.0.0.0"
 PUBLIC_PATH="public"
 LOG_DIR="."
-SERVER_URL="https://VelociraptorServer:8000/"
-DATASTORE_LOCATION="./"
-FILESTORE_DIRECTORY="./"
 CLIENT_DIR="/velociraptor/clients"
 
 # Move binaries into place


### PR DESCRIPTION
- Move the base ubuntu image to 20.04
- Moved Velociraptor to 0.6.4
- Removed legacy variables from entrypoints file. 


Verified this on a fresh docker deploy + agent install without any issues using the repacked configs. 