### PR TITLE
Update entrypoint to repack .msi package

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -28,6 +28,7 @@ fi
 ./velociraptor config repack --exe clients/linux/velociraptor_client client.config.yaml clients/linux/velociraptor_client_repacked
 ./velociraptor config repack --exe clients/mac/velociraptor_client client.config.yaml clients/mac/velociraptor_client_repacked
 ./velociraptor config repack --exe clients/windows/velociraptor_client.exe client.config.yaml clients/windows/velociraptor_client_repacked.exe
+./velociraptor config repack --msi clients/windows/velociraptor_client.msi client.config.yaml clients/windows/velociraptor_client_repacked.msi
 
 # Start Velocoraptor
 ./velociraptor --config server.config.yaml frontend -v


### PR DESCRIPTION
Hi,

I propose you this change to permit the auto repack of the **velociraptor_client_repacked.msi** package.
In this way it will be simplier for users using Windows service install.
https://docs.velociraptor.app/docs/deployment/clients/#repacking-client-configuration-into-the-windows-msi

Kind regards
