### PR TITLE
add: certificate renewal support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x entrypoint && \
     wget -O /opt/velociraptor/windows/velociraptor_client.exe "$WINDOWS_EXE" && \
     wget -O /opt/velociraptor/windows/velociraptor_client.msi "$WINDOWS_MSI" && \
     # Clean up 
-    apt-get remove -y --purge curl wget jq && \
+    apt-get remove -y --purge wget && \
     apt-get clean
 WORKDIR /velociraptor 
 CMD ["/entrypoint"]

--- a/entrypoint
+++ b/entrypoint
@@ -21,6 +21,16 @@ if [ ! -f server.config.yaml ]; then
 	./velociraptor --config server.config.yaml user add $VELOX_USER $VELOX_PASSWORD --role $VELOX_ROLE
 fi
 
+# Check Server Certificate Status, Re-generate if it's expiring in 24-hours or less
+if true | ./velociraptor --config server.config.yaml config show --json | jq -r .Frontend.certificate | openssl x509 -text -enddate -noout -checkend 86400 >/dev/null; then
+  echo "Skipping renewal, certificate is not expired"
+else
+  echo "Certificate is expired, rotating certificate."
+  ./velociraptor --config ./server.config.yaml config rotate_key > /tmp/server.config.yaml
+  cp ./server.config.yaml ./server.config.yaml.bak
+  mv /tmp/server.config.yaml /velociraptor/.
+fi
+
 # Re-generate client config in case server config changed
 ./velociraptor --config server.config.yaml config client > client.config.yaml
 


### PR DESCRIPTION
resolves #15. Tested this on an expired certificate, and on a valid one without issues. It relies on 2 programs curl/jq to validate the certificate which where originally being removed in the Docker build.