### PR TITLE
Added directory for custom artifacts

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -6,6 +6,7 @@ LOG_DIR="."
 DATASTORE_LOCATION="./"
 FILESTORE_DIRECTORY="./"
 CLIENT_DIR="/velociraptor/clients"
+ARTIFACTS_DIR="/velociraptor/artifacts"
 
 # Move binaries into place
 cp /opt/velociraptor/linux/velociraptor . && chmod +x velociraptor
@@ -41,4 +42,4 @@ fi
 ./velociraptor config repack --msi clients/windows/velociraptor_client.msi client.config.yaml clients/windows/velociraptor_client_repacked.msi
 
 # Start Velocoraptor
-./velociraptor --config server.config.yaml frontend -v
+./velociraptor --config server.config.yaml frontend --definitions=$ARTIFACTS_DIR -v


### PR DESCRIPTION
Hello,

the current version of the docker image does not allow to include custom artifacts at startup. This pull request adds the capability to do so. For example, in `docker-compose.yaml`, you could now add 

```yaml
environment:
  [...]
  - ${VELO_CUSTOM_ARTIFACTS_DIR}:/velociraptor/artifacts
```

Referencing 

```bash
VELO_CUSTOM_ARTIFACTS_DIR=/path/to/custom/artifacts
```

in `.env`.

Best regards,
Jannik